### PR TITLE
alias logger.write to logger.log

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -123,4 +123,6 @@ Logger.prototype = {
 
 };
 
+Logger.prototype.write = Logger.prototype.log;
+
 module.exports = Logger;


### PR DESCRIPTION
some of the docs out there use `logger.write()` instead of the `logger.log()` in the interface. i figured it's just easier to alias it but leave it up to you to correct docs instead.
